### PR TITLE
lineage-sdk: Add LineageStatusBarItem interfaces

### DIFF
--- a/sdk/src/java/org/lineageos/internal/statusbar/LineageStatusBarItem.java
+++ b/sdk/src/java/org/lineageos/internal/statusbar/LineageStatusBarItem.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2018 The LineageOS project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.lineageos.internal.statusbar;
+
+import android.graphics.Rect;
+import android.view.View;
+import android.view.ViewParent;
+
+public class LineageStatusBarItem {
+
+    public interface Manager {
+        public void addDarkReceiver(DarkReceiver darkReceiver);
+        public void addVisibilityReceiver(VisibilityReceiver visibilityReceiver);
+    }
+
+    public interface DarkReceiver {
+        public void onDarkChanged(Rect area, float darkIntensity, int tint);
+        public void setFillColors(int darkColor, int lightColor);
+    }
+
+    public interface VisibilityReceiver {
+        public void onVisibilityChanged(boolean isVisible);
+    }
+
+    // Locate parent LineageStatusBarItem.Manager
+    public static Manager findManager(View v) {
+        ViewParent parent = v.getParent();
+        if (parent == null) {
+            return null;
+        } else if (parent instanceof Manager) {
+            return (Manager) parent;
+        } else if (parent instanceof View) {
+            return findManager((View) parent);
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
*) Introduce LineageStatusBarItem class that contains interfaces
   and utility methods that can be used by status bar items that
   that are hosted here in the lineage-sdk in order to communicate
   with systemui.

*) Nested interface: Manager
   Implemented by layout view LineageStatusBarItemHolder in systemui.
   Contains methods that are used to request receipt of certain
   systemui events.

*) Nested interface: DarkReceiver
   Can be used to listen for systemui DarkReceiver events.

*) Nested interface: VisibilityReceiver
   Can be used to listen for changes in visibility of a statusbar item.
   Works even if the statusbar item sets it's own visibility to GONE.

*) Util method: findManager(View v) walks up through parent views to
   look for something that implements Manager.

*) Systemui side that provides a layout that implements Manager:
   https://review.lineageos.org/#/c/202265/

Change-Id: Ie237db5bfac9994b87de39372505cd61c39d89ee

Signed-off-by: Akhil Narang <akhilnarang.1999@gmail.com>